### PR TITLE
avoid crashing on Ruby 2.3.1 when fd is closed

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -302,6 +302,9 @@ module INotify
         # If the IO has already been closed, reading from it will cause
         # Errno::EBADF.
         return nil
+      rescue IOError => ex
+        return nil if ex.message =~ /stream closed/
+        raise
       end
 
       tries = 0


### PR DESCRIPTION
#### Summary

When fd is closed, `process` crashes with `IOError` (while currently only `EBADF` is checked for).
#### Why this broke

Likely ever since the IO patches were added, the different IO/fd api used raises a different exception.
#### How to reproduce

Ugly minimal one-liner (to be run in an empty directory):

``` bash
(/bin/echo "source 'http://rubygems.org'"; echo "gem 'guard'") > Gemfile && bundle install && touch Guardfile && rm -f out.txt && tmux new-session 'echo exit | bundle exec guard > out.txt 2>&1'; cat out.txt
```

Result: crashes every single time on my setup.
#### Disclaimers

Only tested on Ruby 2.3.1 MRI, Linux.
