### PR TITLE
Add test environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.bundle
 /.yardoc
+/Gemfile.lock
 /doc
 /pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+sudo: false
+before_install:
+  - gem install bundler
+rvm:
+- 2.2.7
+- 2.3.4
+- 2.4.1
+- ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem 'rake', '~> 12.0.0'
+gem 'jeweler', '~> 2.3.3'

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ begin
     gem.authors = ["Nathan Weizenbaum"]
     gem.add_dependency "ffi", ">= 0.5.0"
     gem.add_development_dependency "yard", ">= 0.4.0"
+    gem.add_development_dependency "rspec", "~> 3.6.0"
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError
@@ -52,3 +53,10 @@ rescue LoadError
     abort "YARD is not available. In order to run yardoc, you must: sudo gem install yard"
   end
 end
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new do |t|
+  t.ruby_opts = '-w'
+end
+
+task :default => [:spec]

--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -43,13 +43,16 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<ffi>, [">= 0.5.0"])
       s.add_development_dependency(%q<yard>, [">= 0.4.0"])
+      s.add_development_dependency(%q<rspec>, ["~> 3.6.0"])
     else
       s.add_dependency(%q<ffi>, [">= 0.5.0"])
       s.add_dependency(%q<yard>, [">= 0.4.0"])
+      s.add_dependency(%q<rspec>, ["~> 3.6.0"])
     end
   else
     s.add_dependency(%q<ffi>, [">= 0.5.0"])
     s.add_dependency(%q<yard>, [">= 0.4.0"])
+    s.add_dependency(%q<rspec>, ["~> 3.6.0"])
   end
 end
 

--- a/spec/rb-inotify/errors_spec.rb
+++ b/spec/rb-inotify/errors_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe INotify do
+  describe "QueueOverflowError" do
+    it "exists" do
+      expect(INotify::QueueOverflowError).to be_truthy
+    end
+  end
+end

--- a/spec/rb-inotify_spec.rb
+++ b/spec/rb-inotify_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe INotify do
+  describe "version" do
+    it "exists" do
+      expect(INotify::VERSION).to be_truthy
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'rb-inotify'
+require 'rspec'


### PR DESCRIPTION
This fixes #62 .

This is a use case to test.

```
$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]

$ bundle -v
Bundler version 1.14.6

$ git clone git@github.com:nex3/rb-inotify.git

$ cd rb-inotify

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * addressable (2.5.1)
  * builder (3.2.3)
  * bundler (1.14.6)
  * descendants_tracker (0.0.4)
  * faraday (0.9.2)
  * ffi (1.9.18)
  * git (1.3.0)
  * github_api (0.11.3)
  * hashie (3.5.5)
  * highline (1.7.8)
  * jeweler (2.3.3)
  * jwt (1.5.6)
  * mini_portile2 (2.1.0)
  * minitest (5.10.1)
  * multi_json (1.12.1)
  * multi_xml (0.6.0)
  * multipart-post (2.0.0)
  * nokogiri (1.6.8.1)
  * oauth2 (1.3.1)
  * psych (2.2.4)
  * public_suffix (2.0.5)
  * rack (2.0.1)
  * rake (12.0.0)
  * rb-inotify (0.9.8)
  * rdoc (5.1.0)
  * semver2 (3.4.2)
  * thread_safe (0.3.6)
  * yard (0.9.8)

$ bundle exec rake -T
...
rake test                # Run tests
...

$ bundle exec rake test
...
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

I also prepared a file `.travis.yml` to test it on Traivs CI.
This integration CI is often used for the ruby gem packages.
I added officially supported rubies in it.
I also added ruby-head as allow_failures.
This is good practice.
Because we can see the the result of the new version Ruby and prepare in advance.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

So, we can start testing with Travis CI too after you will activate it from below URL.
https://travis-ci.org/nex3/rb-inotify
